### PR TITLE
Fix Vim detection

### DIFF
--- a/gh-ph
+++ b/gh-ph
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
 
 : "${GH_PH_HISTORY_FENCE:="=== GH HISTORY FENCE ==="}"
 : "${GH_PH_HISTORY_FORMAT:="### %H %s%n%n%b%n"}"

--- a/gh-ph
+++ b/gh-ph
@@ -9,7 +9,7 @@ set -e
 
 function is_vim() {
     local gh_ppid
-    gh_ppid="$(ps -o ppid= $PPID)"
+    gh_ppid="$(ps -o ppid= $PPID | tr -d ' ')"
     [[ "$(ps -o comm= "$gh_ppid")" =~ ^n?vim$ ]]
 }
 


### PR DESCRIPTION

# Description

Sometimes the PID `$gh_ppid` can have leading spaces.

# Changes

<!-- === GH HISTORY FENCE === -->
### 377d7d163ee3a238c9371355fc5103d6babb164a fix: Remove spaces from PID in Vim detection

gh_ppid may have leading spaces.


### 1d3e235aeafbd5439a34f669a871a12085853708 improvement: Enable pipefail option



<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->

No.
