### PR TITLE
Support gh cli template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,9 @@
 
 # Changes
 
+<!-- === GH HISTORY FORMAT FENCE === --> <!--
+### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
+--> <!-- === GH HISTORY FORMAT FENCE === -->
 <!-- === GH HISTORY FENCE === -->
 
 <!-- === GH HISTORY FENCE === -->

--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ Per template/section formats can be configured using inline format fences. For e
 
 # Details
 <!-- === GH HISTORY FORMAT FENCE === --> <!--
-### %H %s%n%n%b%n
+### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
 --> <!-- === GH HISTORY FORMAT FENCE === -->
 <!-- === GH HISTORY FENCE === -->
 <!-- === GH HISTORY FENCE === -->
 ```
+
+By default it runs history format through [gh format](https://cli.github.com/manual/gh_help_formatting) then [Git pretty formats](https://git-scm.com/docs/pretty-formats).

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: Marker fences for git-log format strings in pull request bodies
     required: false
     default: "=== GH HISTORY FORMAT FENCE ==="
+  gh_template:
+    description: Preprocess git-log format using gh Go template
+    required: false
+    default: "1"
 runs:
   using: "composite"
   steps:
@@ -24,5 +28,6 @@ runs:
           GH_PH_HISTORY_FENCE='${{ inputs.fence }}' \
           GH_PH_HISTORY_FORMAT='${{ inputs.format }}' \
           GH_PH_HISTORY_FORMAT_FENCE='${{ inputs.format_fence }}' \
+          GH_PH_HISTORY_FORMAT_GH_TEMPLATE='${{ inputs.gh_template }}' \
           $GITHUB_ACTION_PATH/gh-ph
       shell: bash

--- a/gh-ph
+++ b/gh-ph
@@ -6,6 +6,7 @@ set -o pipefail
 : "${GH_PH_HISTORY_FENCE:="=== GH HISTORY FENCE ==="}"
 : "${GH_PH_HISTORY_FORMAT:="### %H %s%n%n%b%n"}"
 : "${GH_PH_HISTORY_FORMAT_FENCE:="=== GH HISTORY FORMAT FENCE ==="}"
+: "${GH_PH_HISTORY_FORMAT_GH_TEMPLATE:="1"}"
 : "${GH_PH_PAGER:="bat"}"
 
 function is_vim() {
@@ -14,9 +15,24 @@ function is_vim() {
     [[ "$(ps -o comm= "$gh_ppid")" =~ ^n?vim$ ]]
 }
 
+function gh_template() {
+    local format="$1"
+    local fields
+    fields="$(gh pr view --json |& tail -n+2 | tr -d ' ' | paste -d, -s)"
+    gh pr view --json "$fields" --template "$format"
+}
+
+function git_log_format() {
+    if [[ -z "$GH_PH_HISTORY_FORMAT_GH_TEMPLATE" ]] || [[ "$GH_PH_HISTORY_FORMAT_GH_TEMPLATE" -eq 0 ]]; then
+        printf '%s' "$GH_PH_HISTORY_FORMAT"
+    else
+        printf '%s' "$(gh_template "$GH_PH_HISTORY_FORMAT")"
+    fi
+}
+
 function render_changes() {
     local target_branch="$1"
-    git log --reverse --format="$GH_PH_HISTORY_FORMAT" "$target_branch.."
+    git log --reverse --format="$(git_log_format)" "$target_branch.."
 }
 
 function inject_history() {


### PR DESCRIPTION
# Description

Run the original format through [gh format](https: //cli.github.com/manual/gh_help_formatting)
first by default.

Main motivation to support this was to generate commit links in the
format of `https://github.com/<owner>/<project>/pull/<num>/commits/<sha>`.
By default it's `https://github.com/<owner>/<project>/commits/<sha>` which
doesn't show the PR context or review buttons.

This behaviour can be disabled by `export GH_PH_HISTORY_FORMAT_GH_TEMPLATE=0`.

# Changes

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->

<!-- === GH HISTORY FENCE === -->
### [`324f8e6`](https://github.com/Frederick888/gh-ph/pull/4/commits/324f8e6eb679f795e12d84c29c10df4e12a09394) feat: Preprocess git-log format with gh template

Run the original log format through GitHub CLI's Go template [1] so that
we can grab some GitHub-specific info, such as PR URL, author's GitHub
username, etc.

This can be disabled by setting GH_PH_HISTORY_FORMAT_GH_TEMPLATE=0.

[1] https://cli.github.com/manual/gh_help_formatting


### [`6349832`](https://github.com/Frederick888/gh-ph/pull/4/commits/6349832ca213e0b80e94f141667c868cccae766f) docs: Link gh and Git format docs; update example



### [`8f52b89`](https://github.com/Frederick888/gh-ph/pull/4/commits/8f52b891fb8037ea831cdf5f6bfe48594c0938f5) docs: Use commit links for review in PR template



<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->

It _can_ be a breaking change. But since I didn't change the default
format and gh format leaves it untouched, the impact should be minimal.
