### PR TITLE
ci: Migrate set-output to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,8 @@ jobs:
         id: release_type
         shell: bash
         run: |
-          is_pre='false'
-          [[ "$GITHUB_REF_NAME" == *"-"* ]] && is_pre='true'
-          printf '::set-output name=is_pre::%s\n' "$is_pre"
+          [[ "$GITHUB_REF_NAME" == *"-"* ]] && is_pre='true' || is_pre='false'
+          printf '%s=%s\n' 'is_pre' "$is_pre" >> $GITHUB_OUTPUT
       - name: Create Release
         id: create_release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
# Description

<!-- # Changes -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`3ef2937`](https://github.com/Frederick888/gh-ph/pull/5/commits/3ef293771ad9ae9ff42ed0c68ede58cca4413e98) ci: Migrate set-output to GITHUB_OUTPUT

[1] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
