### PR TITLE
fix: Retain leading & trailing spaces

### DIFF
--- a/gh-ph
+++ b/gh-ph
@@ -54,7 +54,7 @@ function inject_history() {
     local line
     local rendering=0
     local updating_format=0
-    while read -r line; do
+    while IFS='' read -r line; do
         if [[ "$rendering" -eq 1 ]] && [[ "$line" != *"$GH_PH_HISTORY_FENCE"* ]]; then
             # Placing format fences inside history fences is not allowed
             continue


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`0f44d6f`](https://github.com/Frederick888/gh-ph/pull/6/commits/0f44d6f495c8b5cda12faacaadc4f56ca7163170) fix: Retain leading & trailing spaces

It removed leading and trailing spaces outside fences, which could mess
up body formatting sometimes.


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Testing zone

```json
{
"hello": "world",
"foo": "bar"
}
```
