### PR TITLE
fix: Check out pull/[id]/merge for PRs from forks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
   steps:
     - run: |
         git checkout "$GITHUB_BASE_REF"
-        git checkout "$GITHUB_HEAD_REF"
+        git checkout "$GITHUB_HEAD_REF" || git checkout "${GITHUB_REF/refs\//}"
         printf 'y' | \
           GH_PH_PAGER='cat' \
           GH_PH_DEBUG='${{ inputs.debug }}' \


### PR DESCRIPTION
# Changes

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`bdef7fc`](https://github.com/Frederick888/gh-ph/pull/8/commits/bdef7fca09257698841fd314efeb8fa0b67bcf01) fix: Check out pull/[id]/merge for PRs from forks

When a PR arrives from a fork, the checkout in Actions doesn't have the
branch in the fork. Instead, it has pull/[id]/merge.


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
