### PR TITLE
fix: Fix no current branch error for PRs from forks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,10 @@ runs:
   steps:
     - run: |
         git checkout "$GITHUB_BASE_REF"
-        git checkout "$GITHUB_HEAD_REF" || git checkout "${GITHUB_REF/refs\//}"
+        if ! git checkout "$GITHUB_HEAD_REF"; then
+          git checkout "${GITHUB_REF/refs\//}^2"
+          git checkout -b "$GITHUB_HEAD_REF"
+        fi
         printf 'y' | \
           GH_PH_PAGER='cat' \
           GH_PH_DEBUG='${{ inputs.debug }}' \


### PR DESCRIPTION
# Changes

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`fd0ad18`](https://github.com/Frederick888/gh-ph/pull/9/commits/fd0ad18924ef1a3f8d6676f8179fad50bf720003) fix: Fix no current branch error for PRs from forks

[1] fixed the checkout but pull/[id]/merge is only a reference. Now
using this reference we should create a branch.

[1] https://github.com/Frederick888/gh-ph/commit/bdef7fca09257698841fd314efeb8fa0b67bcf01


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
