### PR TITLE
docs: Action permissions for PRs

### DIFF
--- a/.github/workflows/gh-ph.yml
+++ b/.github/workflows/gh-ph.yml
@@ -3,6 +3,10 @@ name: Pull request history
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   gh-ph:
     name: Add commit history to pull request description

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ First, visit your repository's Settings -> Actions -> General, and select 'Read 
 Then add the fences to your pull request templates, and finally set up a job as below:
 
 ```yaml
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   gh-ph:
     name: Add commit history to pull request description


### PR DESCRIPTION
# Changes

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`c263e58`](https://github.com/Frederick888/gh-ph/pull/11/commits/c263e58329915b4496fc34c90c2829ebe7c14779) docs: Action permissions for PRs

When running for a PR from a fork, GITHUB_TOKEN usually by default has
only read-only permissions.


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
