### PR TITLE
Fixes for PRs from public forks

### DIFF
--- a/.github/workflows/gh-ph.yml
+++ b/.github/workflows/gh-ph.yml
@@ -1,7 +1,7 @@
 name: Pull request history
 
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: read

--- a/.github/workflows/gh-ph.yml
+++ b/.github/workflows/gh-ph.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: Frederick888/gh-ph@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   create_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Conventional Commit Changelog

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,6 +11,6 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Then add the fences to your pull request templates, and finally set up a job as 
 
 ```yaml
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: read
@@ -60,8 +60,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
-
-_Note_: [`GITHUB_TOKEN`](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/) (and [secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow)) does not work on PRs from public forks. Private repositories can consider [sending write tokens to workflows from pull requests](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#enabling-workflows-for-forks-of-private-repositories).
 
 # Configuration
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
     name: Add commit history to pull request description
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 100
       - run: |

--- a/action.yml
+++ b/action.yml
@@ -26,10 +26,7 @@ runs:
   steps:
     - run: |
         git checkout "$GITHUB_BASE_REF"
-        if ! git checkout "$GITHUB_HEAD_REF"; then
-          git checkout "${GITHUB_REF/refs\//}^2"
-          git checkout -b "$GITHUB_HEAD_REF"
-        fi
+        gh pr checkout "$GH_PH_PULL_REQUEST_ID"
         printf 'y' | \
           GH_PH_PAGER='cat' \
           GH_PH_DEBUG='${{ inputs.debug }}' \


### PR DESCRIPTION
# Changes

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`17b4944`](https://github.com/Frederick888/gh-ph/pull/12/commits/17b49448caa9ba91af270d76d5f75bba1e53b679) fix: Use gh pr checkout instead of relying on actions/checkout

This allows running gh-ph using pull_request_target as the triggering
event, which unlike the pull_request event, gives the GITHUB_TOKEN
writer permissions so that gh-ph can update the PR.

But when using pull_request_target, actions/checkout does not initialise
the PR head. Here we simply use gh CLI instead.


### [`f81c1f2`](https://github.com/Frederick888/gh-ph/pull/12/commits/f81c1f2142cbbf74aeaa38509dfa5ec398e1d74a) docs: Suggest using pull_request_target

This should allow gh-ph to run on PRs from public forks.


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
