### PR TITLE
feat: Temporary workaround for cli/cli#9160

### DIFF
--- a/gh-ph
+++ b/gh-ph
@@ -26,7 +26,7 @@ function gh_template() {
     local format="$1"
     if [[ -z "$GH_TEMPLATE_CACHE" ]]; then
         local fields
-        fields="$(set -eo pipefail; (gh pr view --json 2>&1 || true) | tail -n+2 | tr -d ' ' | paste -d, -s -)"
+        fields="$(set -eo pipefail; (gh pr view --json 2>&1 || true) | tail -n+2 | tr -d ' ' | grep -v stateReason | paste -d, -s -)"
         GH_TEMPLATE_CACHE="$(set -eo pipefail; gh pr view "$GH_PH_PULL_REQUEST_ID" --json "$fields" --template "$format")"
     fi
     printf '%s' "$GH_TEMPLATE_CACHE"


### PR DESCRIPTION
# Changes

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`8eb0663`](https://github.com/Frederick888/gh-ph/pull/13/commits/8eb0663c0e8aadc827c88428f56cba2e85b39ec0) feat: Temporary workaround for cli/cli#9160

[1] https://github.com/cli/cli/issues/9160


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
