### PR TITLE
fix: Use CRLF

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 - [`jq`](https://github.com/stedolan/jq)
 - [`bat`](https://github.com/sharkdp/bat)
+- Command UNIX CLI utilities such as `tr`, `grep`, `sed`, etc.
 
 # Usage
 

--- a/gh-ph
+++ b/gh-ph
@@ -97,20 +97,24 @@ function pager() {
     esac
 }
 
+function unix2dos() {
+    tr -d $'\r' | sed 's/$/\r/'
+}
+
 PR_DETAILS="$(set -eo pipefail; gh pr view "$GH_PH_PULL_REQUEST_ID" --json baseRefName,body)"
 PR_BASE="$(set -eo pipefail; jq -r '.baseRefName' <<<"$PR_DETAILS")"
 PR_BODY="$(set -eo pipefail; jq -r '.body' <<<"$PR_DETAILS")"
 
-inject_history "$PR_BASE" <<<"$PR_BODY" | pager
+inject_history "$PR_BASE" <<<"$PR_BODY" | unix2dos | pager
 
 if read -r -n1 -p 'Update pull request body? [y/n] '; then
     printf '\n'
     if [[ "$REPLY" == 'y' ]]; then
-        inject_history "$PR_BASE" <<<"$PR_BODY" | gh pr edit "$GH_PH_PULL_REQUEST_ID" --body-file -
+        inject_history "$PR_BASE" <<<"$PR_BODY" | unix2dos | gh pr edit "$GH_PH_PULL_REQUEST_ID" --body-file -
     else
         printf 'Aborted\n'
     fi
 elif is_vim; then
     printf '\nVim detected\n'
-    inject_history "$PR_BASE" <<<"$PR_BODY" | gh pr edit "$GH_PH_PULL_REQUEST_ID" --body-file -
+    inject_history "$PR_BASE" <<<"$PR_BODY" | unix2dos | gh pr edit "$GH_PH_PULL_REQUEST_ID" --body-file -
 fi


### PR DESCRIPTION
# Changes

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`a15970d`](https://github.com/Frederick888/gh-ph/pull/14/commits/a15970daaa439ba3d5bf1aaed9fe8489918fb3f8) fix: Use CRLF

When editing PRs in GitHub web, PR bodies use CRLF. But since gh-cli
doesn't convert body inputs from LF to CRLF, this can lead to mixed
LF/CRLF.

Ideally we identify what a PR currently uses (if it was submitted via
CLI or web), but simply using CRLF across the board isn't too bad
either. Most modern text editors can handle both anyway.

[1] https://github.com/actions/runner/issues/1462


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No


