### PR TITLE
revert: "feat: Temporary workaround for cli/cli#9160"

### DIFF
--- a/gh-ph
+++ b/gh-ph
@@ -26,7 +26,7 @@ function gh_template() {
     local format="$1"
     if [[ -z "$GH_TEMPLATE_CACHE" ]]; then
         local fields
-        fields="$(set -eo pipefail; (gh pr view --json 2>&1 || true) | tail -n+2 | tr -d ' ' | grep -v stateReason | paste -d, -s -)"
+        fields="$(set -eo pipefail; (gh pr view --json 2>&1 || true) | tail -n+2 | tr -d ' ' | paste -d, -s -)"
         GH_TEMPLATE_CACHE="$(set -eo pipefail; gh pr view "$GH_PH_PULL_REQUEST_ID" --json "$fields" --template "$format")"
     fi
     printf '%s' "$GH_TEMPLATE_CACHE"


### PR DESCRIPTION
# Changes

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`7d5cf02`](https://github.com/Frederick888/gh-ph/pull/15/commits/7d5cf02a901d07009e5528e32c146b506f85fc96) revert: "feat: Temporary workaround for cli/cli#9160"

This reverts commit 8eb0663c0e8aadc827c88428f56cba2e85b39ec0.

The gh-cli issue has been fixed.


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
