### PR TITLE
feat: Use base@{push} if it's newer than base

### DIFF
--- a/gh-ph
+++ b/gh-ph
@@ -105,6 +105,10 @@ PR_DETAILS="$(set -eo pipefail; gh pr view "$GH_PH_PULL_REQUEST_ID" --json baseR
 PR_BASE="$(set -eo pipefail; jq -r '.baseRefName' <<<"$PR_DETAILS")"
 PR_BODY="$(set -eo pipefail; jq -r '.body' <<<"$PR_DETAILS")"
 
+if git rev-parse --quiet --verify --abbrev-ref "$PR_BASE@{push}" >/dev/null && git merge-base --is-ancestor "$PR_BASE" "$PR_BASE@{push}"; then
+    PR_BASE="$PR_BASE@{push}"
+fi
+
 inject_history "$PR_BASE" <<<"$PR_BODY" | unix2dos | pager
 
 if read -r -n1 -p 'Update pull request body? [y/n] '; then


### PR DESCRIPTION
# Changes

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`4eeb80b`](https://github.com/Frederick888/gh-ph/pull/16/commits/4eeb80bce4fcf6e54cadf3d45c24ec655e36f9fa) feat: Use base@{push} if it's newer than base

If a user keeps rebasing onto origin/base, their local base branch may
be outdated.

Of course base@{push} doesn't always point to the actual remote base in
a triangular workflow, but gh-ph has been operating under the assumption
that baseRefName *locally* is the correct base.


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
